### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.0

### DIFF
--- a/.github/workflows/auto_check.yml
+++ b/.github/workflows/auto_check.yml
@@ -1,9 +1,11 @@
 name: Bump upstream version
 
 on:
-  push:
   schedule:
     - cron: "00 */4 * * *"
+  push:
+    branches:
+      - "master"
 jobs:
   bump-upstream:
     runs-on: ubuntu-latest

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -7,10 +7,7 @@
   "shortDescription": "Prysm Medalla ETH2.0 Beacon chain",
   "description": "Prysm: a Go implementation of the Ethereum 2.0 Serenity protocol and open source project created by Prysmatic Labs. Beacon node which powers the beacon chain at the core of Ethereum 2.0",
   "type": "service",
-  "architectures": [
-    "linux/amd64",
-    "linux/arm64"
-  ],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)"
@@ -26,9 +23,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.20"
   },
-  "categories": [
-    "Blockchain"
-  ],
+  "categories": ["Blockchain"],
   "links": {
     "homepage": "https://prylabs.net/participate?node=dappnode",
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-medalla-beacon-chain",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
-version: '3.4'
+version: "3.4"
 services:
   prysm-medalla-beacon-chain.dnp.dappnode.eth:
-    image: 'prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.9'
+    image: "prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.9"
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-alpha.27
+        UPSTREAM_VERSION: v1.0.0-beta.0
     volumes:
-      - 'data:/data'
+      - "data:/data"
     ports:
-      - '13000'
-      - '12000'
+      - "13000"
+      - "12000"
     restart: always
     environment:
-      - 'HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545'
+      - "HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545"
       - EXTRA_OPTS
 volumes:
   data: {}


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-alpha.27 to [v1.0.0-beta.0](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.0)