### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-medalla-beacon-chain.dnp.dappnode.eth",
   "version": "1.0.9",
-  "upstreamVersion": "v1.0.0-beta.0",
+  "upstreamVersion": "v1.0.0-beta.1",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm Medalla ETH2.0 Beacon chain",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,19 @@
-version: '3.4'
+version: "3.4"
 services:
   prysm-medalla-beacon-chain.dnp.dappnode.eth:
-    image: 'prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.9'
+    image: "prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.9"
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-beta.0
+        UPSTREAM_VERSION: v1.0.0-beta.1
     volumes:
-      - 'data:/data'
+      - "data:/data"
     ports:
-      - '13000'
-      - '12000'
+      - "13000"
+      - "12000"
     restart: always
     environment:
-      - 'HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545'
+      - "HTTP_WEB3PROVIDER=http://goerli-geth.dappnode:8545"
       - EXTRA_OPTS
 volumes:
   data: {}


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.0 to [v1.0.0-beta.1](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.1)