### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "prysm-medalla-beacon-chain.dnp.dappnode.eth",
   "version": "1.0.10",
-  "upstreamVersion": "v1.0.0-beta.1",
+  "upstreamVersion": "v1.0.0-beta.2",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm Medalla ETH2.0 Beacon chain",
@@ -22,9 +22,7 @@
   "requirements": {
     "minimumDappnodeVersion": "0.2.20"
   },
-  "categories": [
-    "Blockchain"
-  ],
+  "categories": ["Blockchain"],
   "links": {
     "homepage": "https://prylabs.net/participate?node=dappnode",
     "readme": "https://github.com/dappnode/DAppNodePackage-prysm-medalla-beacon-chain",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
-version: '3.4'
+version: "3.4"
 services:
   prysm-medalla-beacon-chain.dnp.dappnode.eth:
-    image: 'prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.10'
+    image: "prysm-medalla-beacon-chain.dnp.dappnode.eth:1.0.10"
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-beta.1
+        UPSTREAM_VERSION: v1.0.0-beta.2
     volumes:
-      - 'data:/data'
+      - "data:/data"
     ports:
-      - '13000'
-      - '12000'
+      - "13000"
+      - "12000"
     restart: always
     environment:
-      HTTP_WEB3PROVIDER: 'http://goerli-geth.dappnode:8545'
-      EXTRA_OPTS: ''
-      GRPC_GATEWAY_CORSDOMAIN: 'http://prysm-medalla-validator.dappnode'
+      HTTP_WEB3PROVIDER: "http://goerli-geth.dappnode:8545"
+      EXTRA_OPTS: ""
+      GRPC_GATEWAY_CORSDOMAIN: "http://prysm-medalla-validator.dappnode"
 volumes:
   data: {}


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.1 to [v1.0.0-beta.2](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.2)