### PR TITLE
bump prysmaticlabs/prysm to v1.0.0-beta.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,16 +1,13 @@
 {
   "name": "prysm-medalla-beacon-chain.dnp.dappnode.eth",
   "version": "1.0.11",
-  "upstreamVersion": "v1.0.0-beta.2",
+  "upstreamVersion": "v1.0.0-beta.3",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Prysm Medalla ETH2.0 Beacon chain",
   "description": "Prysm: a Go implementation of the Ethereum 2.0 Serenity protocol and open source project created by Prysmatic Labs. Beacon node which powers the beacon chain at the core of Ethereum 2.0",
   "type": "service",
-  "architectures": [
-    "linux/amd64",
-    "linux/arm64"
-  ],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "author": "DAppNode Association <admin@dappnode.io> (https://github.com/dappnode)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v1.0.0-beta.2
+        UPSTREAM_VERSION: v1.0.0-beta.3
     volumes:
       - "data:/data"
     ports:


### PR DESCRIPTION
Bumps upstream version

- [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm) from v1.0.0-beta.2 to [v1.0.0-beta.3](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-beta.3)